### PR TITLE
Utility Property Update, Bug fixed for banktrupcty, Changed test variables back to origonal

### DIFF
--- a/gamepieces.js
+++ b/gamepieces.js
@@ -64,7 +64,7 @@ let activePlayers = [
         position: 0,
         gamePiece: "",
         pieceId: "",
-        cash: 0,
+        cash: 1500,
         totalAssets: 0,
         updateTotalAssets: function (){
             this.totalAssets = 0
@@ -286,10 +286,10 @@ let canCloseMortgageArray = []
 
 
 //Function Variables
-let rollDiceOne = () => {return 10}
-let rollDiceTwo = () => {return 2}
-//let rollDiceOne = () =>{return(Math.floor(Math.random() * 6) + 1)}
-//let rollDiceTwo = () =>{return(Math.floor(Math.random() * 6) + 1)}
+//let rollDiceOne = () => {return 10}
+//let rollDiceTwo = () => {return 2}
+let rollDiceOne = () =>{return(Math.floor(Math.random() * 6) + 1)}
+let rollDiceTwo = () =>{return(Math.floor(Math.random() * 6) + 1)}
 let diceOneValue;
 let diceTwoValue = rollDiceTwo();
 let chanceDice = () => {return(Math.floor(Math.random() * 16) + 1)}
@@ -509,6 +509,7 @@ let propertyArray = [
        owner:  "",
        price: 150,
        rent: "", 
+       updateRent: "",
        mortgage: 75,
        mortgageOpen: false, 
        type: "utility",
@@ -812,6 +813,7 @@ let propertyArray = [
        owner: "",
        price: 150,
        rent: "",
+       updateRent: "",
        mortgage: 75,
        mortgageOpen: false,
        type: "utility",

--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@
                         <h2 id="float-screen-game-middle-currentLocation"></h2>
 
                         <!--Pay Rent Insructions-->
-                        <h2 class="hidden" id="payRentTutorialId"></h2>
+                        <div class="hidden" id="payRentTutorialId"></div>
 
                         <!--Bankrupt Warning Message-->
                         <container class="hidden" id="bankruptWarningContainerId">

--- a/styles.css
+++ b/styles.css
@@ -929,6 +929,10 @@ svg{
     grid-template-rows: 100px 60px 60px;
 }
 
+.pay-rent-tutorial{
+    font-size: 1.25em;
+}
+
 #payRentLabelId{
     font-size: 24px;
     padding-bottom: 20px;


### PR DESCRIPTION
- Added method to utility properties to properly update new rent based on current turn dice roll
- Fixed an error where declaring bankruptcy was not transferring properties
- Fixed error where declaring bankruptcy did not add cash to owed players cash
- Fixed error where dicerolls where not working as intended for rolling for doubles to get out of jail
- Fixed dicerolls that were not changed from testing